### PR TITLE
Support Sessions

### DIFF
--- a/MVCGrid/Web/MVCGridHandler.cs
+++ b/MVCGrid/Web/MVCGridHandler.cs
@@ -16,7 +16,7 @@ using System.Web.Routing;
 
 namespace MVCGrid.Web
 {
-    public class MVCGridHandler : IHttpHandler
+    public class MVCGridHandler : IHttpHandler, System.Web.SessionState.IRequiresSessionState
     {
         static object _lock = new object();
         static bool _init = false;


### PR DESCRIPTION
Hi, to properly support sessions ( as for refreshing and using session values in mvcgridconfig.cs to filter data or build the query ) the handler must implement IRequiresSessionState.
