### PR TITLE
fix unnecessary query prefix for engine

### DIFF
--- a/MVCGrid/Engine/GridEngine.cs
+++ b/MVCGrid/Engine/GridEngine.cs
@@ -122,7 +122,7 @@ namespace MVCGrid.Engine
                 model.PagingModel.TotalRecords = totalRecords.Value;
 
                 model.PagingModel.FirstRecord = (currentPageIndex * gridContext.QueryOptions.ItemsPerPage.Value) + 1;
-                if(model.PagingModel.FirstRecord > model.PagingModel.TotalRecords) 
+                if (model.PagingModel.FirstRecord > model.PagingModel.TotalRecords)
                 {
                     model.PagingModel.FirstRecord = model.PagingModel.TotalRecords;
                 }
@@ -154,7 +154,7 @@ namespace MVCGrid.Engine
                 Column renderingColumn = new Column();
                 model.Columns.Add(renderingColumn);
                 renderingColumn.Name = col.ColumnName;
-                renderingColumn.HeaderText = col.HeaderText;
+                renderingColumn.HeaderText = col.HeaderTextExpression != null ? col.HeaderTextExpression() : col.HeaderText;
 
                 if (gridContext.GridDefinition.Sorting && col.EnableSorting)
                 {

--- a/MVCGrid/Engine/GridEngine.cs
+++ b/MVCGrid/Engine/GridEngine.cs
@@ -104,13 +104,13 @@ namespace MVCGrid.Engine
 
             if (model.Rows.Count == 0)
             {
-                model.NoResultsMessage = gridContext.GridDefinition.NoResultsMessage;
+                model.NoResultsMessage = gridContext.GridDefinition.NoResultsMessageExpression != null ? gridContext.GridDefinition.NoResultsMessageExpression() : gridContext.GridDefinition.NoResultsMessage;
             }
 
-            model.NextButtonCaption = gridContext.GridDefinition.NextButtonCaption;
-            model.PreviousButtonCaption = gridContext.GridDefinition.PreviousButtonCaption;
-            model.SummaryMessage = gridContext.GridDefinition.SummaryMessage;
-            model.ProcessingMessage = gridContext.GridDefinition.ProcessingMessage;
+            model.NextButtonCaption = gridContext.GridDefinition.NextButtonCaptionExpression != null ? gridContext.GridDefinition.NextButtonCaptionExpression() : gridContext.GridDefinition.NextButtonCaption;
+            model.PreviousButtonCaption = gridContext.GridDefinition.PreviousButtonCaptionExpression != null ? gridContext.GridDefinition.PreviousButtonCaptionExpression() : gridContext.GridDefinition.PreviousButtonCaption;
+            model.SummaryMessage = gridContext.GridDefinition.SummaryMessageExpression != null ? gridContext.GridDefinition.SummaryMessageExpression() : gridContext.GridDefinition.SummaryMessage;
+            model.ProcessingMessage = gridContext.GridDefinition.ProcessingMessageExpression != null ? gridContext.GridDefinition.ProcessingMessageExpression() : gridContext.GridDefinition.ProcessingMessage;
 
             model.PagingModel = null;
             if (gridContext.QueryOptions.ItemsPerPage.HasValue)

--- a/MVCGrid/Engine/GridEngine.cs
+++ b/MVCGrid/Engine/GridEngine.cs
@@ -261,7 +261,10 @@ namespace MVCGrid.Engine
                 foreach (PropertyDescriptor descriptor in TypeDescriptor.GetProperties(pageParameters))
                 {
                     object obj2 = descriptor.GetValue(pageParameters);
-                    pageParamsDict.Add(descriptor.Name, obj2.ToString());
+                    if (obj2 != null)
+                    {
+                        pageParamsDict.Add(descriptor.Name, obj2.ToString());
+                    }
                 }
             }
             if (grid.PageParameterNames.Count > 0)

--- a/MVCGrid/Interfaces/IMVCGridColumn.cs
+++ b/MVCGrid/Interfaces/IMVCGridColumn.cs
@@ -12,6 +12,7 @@ namespace MVCGrid.Interfaces
         /// Header text to display for the current column, if different from ColumnName.
         /// </summary>
         string HeaderText { get; }
+        Func<string> HeaderTextExpression { get; }
 
         /// <summary>
         /// A unique name for this column

--- a/MVCGrid/Interfaces/IMVCGridDefinition.cs
+++ b/MVCGrid/Interfaces/IMVCGridDefinition.cs
@@ -58,14 +58,26 @@ namespace MVCGrid.Interfaces
         string NoResultsMessage { get; set; }
 
         /// <summary>
+        /// Text to display when there are no results with expression
+        /// </summary>
+        Func<string> NoResultsMessageExpression { get; set; }
+
+        /// <summary>
         /// Text to display on the "next" button
         /// </summary>
         string NextButtonCaption { get; set; }
 
         /// <summary>
+        /// Text to display on the "next" button
+        /// </summary>
+        Func<string> NextButtonCaptionExpression { get; set; }
+
+        /// <summary>
         /// Text to display on the "previous" button
         /// </summary>
         string PreviousButtonCaption { get; set; }
+
+        Func<string> PreviousButtonCaptionExpression { get; set; }
 
         /// <summary>
         /// Summary text to display in grid footer
@@ -73,9 +85,16 @@ namespace MVCGrid.Interfaces
         string SummaryMessage { get; set; }
 
         /// <summary>
+        /// Summary text to display in grid footer
+        /// </summary>
+        Func<string> SummaryMessageExpression { get; set; }
+
+        /// <summary>
         /// Text to display when query is processed
         /// </summary>
         string ProcessingMessage { get; set; }
+
+        Func<string> ProcessingMessageExpression { get; set; }
 
         /// <summary>
         /// Name of function to call before ajax call begins

--- a/MVCGrid/Models/ColumnDefaults.cs
+++ b/MVCGrid/Models/ColumnDefaults.cs
@@ -18,10 +18,12 @@ namespace MVCGrid.Models
             Visible = true;
             SortColumnData = null;
             AllowChangeVisibility = false;
+            HeaderTextExpression = null;
         }
 
         public string ColumnName { get; set; }
         public string HeaderText { get; set; }
+        public Func<string> HeaderTextExpression { get; set; }
         public bool EnableSorting { get; set; }
         public bool HtmlEncode { get; set; }
         public bool EnableFiltering { get; set; }

--- a/MVCGrid/Models/GridColumn.cs
+++ b/MVCGrid/Models/GridColumn.cs
@@ -75,6 +75,8 @@ namespace MVCGrid.Models
             }
         }
 
+        public Func<string> HeaderTextExpression { get; set; }
+
         /// <summary>
         /// Template for formatting cell value
         /// </summary>

--- a/MVCGrid/Models/GridColumnBuilder.cs
+++ b/MVCGrid/Models/GridColumnBuilder.cs
@@ -102,6 +102,12 @@ namespace MVCGrid.Models
             return this;
         }
 
+        public GridColumnBuilder<T1> WithHeaderTextExpression(Func<string> expression)
+        {
+            GridColumn.HeaderTextExpression = expression;
+            return this;
+        }
+
 
         /// <summary>
         /// Enables sorting on this column

--- a/MVCGrid/Models/GridDefaults.cs
+++ b/MVCGrid/Models/GridDefaults.cs
@@ -19,10 +19,15 @@ namespace MVCGrid.Models
             DefaultSortColumn = null;
             DefaultSortDirection = SortDirection.Unspecified;
             NoResultsMessage = "No results.";
+            NoResultsMessageExpression = null;
+            SummaryMessageExpression = null;
             NextButtonCaption = "Next";
+            NextButtonCaptionExpression = null;
             PreviousButtonCaption = "Previous";
+            PreviousButtonCaptionExpression = null;
             SummaryMessage = "Showing {0} to {1} of {2} entries";
             ProcessingMessage = "Processing";
+            ProcessingMessageExpression = null;
             ClientSideLoadingMessageFunctionName = null;
             ClientSideLoadingCompleteFunctionName = null;
             Filtering = false;
@@ -54,11 +59,15 @@ namespace MVCGrid.Models
         public SortDirection DefaultSortDirection { get; set; }
 
         public string NoResultsMessage { get; set; }
+        public Func<string> NoResultsMessageExpression { get; set; }
         public string NextButtonCaption { get; set; }
+        public Func<string> NextButtonCaptionExpression { get; set; }
         public string PreviousButtonCaption { get; set; }
+        public Func<string> PreviousButtonCaptionExpression { get; set; }
         public string SummaryMessage { get; set; }
+        public Func<string> SummaryMessageExpression { get; set; }
         public string ProcessingMessage { get; set; }
-
+        public Func<string> ProcessingMessageExpression { get; set; }
         public string ClientSideLoadingMessageFunctionName { get; set; }
         public string ClientSideLoadingCompleteFunctionName { get; set; }
         public bool Filtering { get; set; }

--- a/MVCGrid/Models/GridDefinition.cs
+++ b/MVCGrid/Models/GridDefinition.cs
@@ -259,24 +259,37 @@ namespace MVCGrid.Models
         public string NoResultsMessage { get; set; }
 
         /// <summary>
+        /// Text to display when there are no results with expression.
+        /// </summary>
+        public Func<string> NoResultsMessageExpression { get; set; }
+
+        /// <summary>
         /// Text to display on the "next" button.
         /// </summary>
         public string NextButtonCaption { get; set; }
+
+        public Func<string> NextButtonCaptionExpression { get; set; }
 
         /// <summary>
         /// Text to display on the "previous" button.
         /// </summary>
         public string PreviousButtonCaption { get; set; }
 
+        public Func<string> PreviousButtonCaptionExpression { get; set; }
+
         /// <summary>
         /// Summary text to display in grid footer
         /// </summary>
         public string SummaryMessage { get; set; }
 
+        public Func<string> SummaryMessageExpression { get; set; }
+
         /// <summary>
         /// Text to display when query is processed
         /// </summary>
         public string ProcessingMessage { get; set; }
+
+        public Func<string> ProcessingMessageExpression { get; set; }
 
         /// <summary>
         /// Name of function to call before ajax call begins

--- a/MVCGrid/Models/MVCGridBuilder.cs
+++ b/MVCGrid/Models/MVCGridBuilder.cs
@@ -225,6 +225,38 @@ namespace MVCGrid.Models
         }
 
         /// <summary>
+        /// Text to display when there are no results with expression
+        /// </summary>
+        public MVCGridBuilder<T1> WithNoResultsMessageExpression(Func<string> expression)
+        {
+            GridDefinition.NoResultsMessageExpression = expression;
+            return this;
+        }
+
+        public MVCGridBuilder<T1> WithNextButtonCaptionExpression(Func<string> expression)
+        {
+            GridDefinition.NextButtonCaptionExpression = expression;
+            return this;
+        }
+
+        public MVCGridBuilder<T1> WithPreviousButtonCaptionExpression(Func<string> expression)
+        {
+            GridDefinition.PreviousButtonCaptionExpression = expression;
+            return this;
+        }
+
+        public MVCGridBuilder<T1> WithSummaryMessageExpression(Func<string> expression)
+        {
+            GridDefinition.SummaryMessageExpression = expression;
+            return this;
+        }
+
+        public MVCGridBuilder<T1> WithProcessingMessageExpression(Func<string> expression)
+        {
+            GridDefinition.ProcessingMessageExpression = expression;
+            return this;
+        }
+        /// <summary>
         /// Name of function to call before ajax call begins
         /// </summary>
         public MVCGridBuilder<T1> WithClientSideLoadingMessageFunctionName(string name)

--- a/MVCGrid/Web/MVCGridHtmlGenerator.cs
+++ b/MVCGrid/Web/MVCGridHtmlGenerator.cs
@@ -182,12 +182,16 @@ namespace MVCGrid.Web
                 foreach (PropertyDescriptor descriptor in TypeDescriptor.GetProperties(pageParameters))
                 {
                     object obj2 = descriptor.GetValue(pageParameters);
-                    pageParamsDict.Add(descriptor.Name, obj2.ToString());
+                    if (obj2 != null)
+                    {
+                        pageParamsDict.Add(descriptor.Name, obj2.ToString());
+                    }
                 }
             }
 
             foreach (var col in pageParamsDict)
             {
+                
                 string val = col.Value;
 
                 if (sb.Length > 0)

--- a/MVCGrid/Web/MVCGridHtmlGenerator.cs
+++ b/MVCGrid/Web/MVCGridHtmlGenerator.cs
@@ -158,8 +158,8 @@ namespace MVCGrid.Web
             if (renderLoadingDiv)
             {
                 sbHtml.AppendFormat("<div id='MVCGrid_Loading_{0}' class='text-center' style='visibility: hidden'>", gridName);
-                sbHtml.AppendFormat("&nbsp;&nbsp;&nbsp;<img src='{0}/ajaxloader.gif' alt='{1}' style='width: 15px; height: 15px;' />", HtmlUtility.GetHandlerPath(), def.ProcessingMessage);
-                sbHtml.AppendFormat("&nbsp;{0}...", def.ProcessingMessage);
+                sbHtml.AppendFormat("&nbsp;&nbsp;&nbsp;<img src='{0}/ajaxloader.gif' alt='{1}' style='width: 15px; height: 15px;' />", HtmlUtility.GetHandlerPath(), def.ProcessingMessageExpression != null ? def.ProcessingMessageExpression() : def.ProcessingMessage);
+                sbHtml.AppendFormat("&nbsp;{0}...", def.ProcessingMessageExpression != null ? def.ProcessingMessageExpression() : def.ProcessingMessage);
                 sbHtml.Append("</div>");
             }
 

--- a/MVCGrid/Web/QueryStringParser.cs
+++ b/MVCGrid/Web/QueryStringParser.cs
@@ -26,7 +26,7 @@ namespace MVCGrid.Web
             string qsKeyPage = grid.QueryStringPrefix + QueryStringSuffix_Page;
             string qsKeySort = grid.QueryStringPrefix + QueryStringSuffix_Sort;
             string qsKeyDirection = grid.QueryStringPrefix + QueryStringSuffix_SortDir;
-            string qsKeyEngine = grid.QueryStringPrefix + QueryStringSuffix_Engine;
+            string qsKeyEngine =  QueryStringSuffix_Engine;
             string qsKeyPageSize = grid.QueryStringPrefix + QueryStringSuffix_ItemsPerPage;
             string qsColumns = grid.QueryStringPrefix + QueryStringSuffix_Columns;
 

--- a/MVCGridExample/Content/MVCGridConfig.txt
+++ b/MVCGridExample/Content/MVCGridConfig.txt
@@ -28,7 +28,6 @@ namespace MVCGridExample
                 .AddColumns(cols =>
                 {
                     cols.Add("Id").WithValueExpression((p, c) => c.UrlHelper.Action("detail", "demo", new { id = p.Id }))
-                        .WithHeaderTextExpression(() => new Random().Next().ToString())
                         .WithValueTemplate("<a href='{Value}'>{Model.Id}</a>", false)
                         .WithPlainTextValueExpression(p => p.Id.ToString());
                     cols.Add("FirstName").WithHeaderText("First Name")
@@ -61,19 +60,17 @@ namespace MVCGridExample
                 //.WithAdditionalSetting(MVCGrid.Rendering.BootstrapRenderingEngine.SettingNameTableClass, "notreal") // Example of changing table css class
                 .WithRetrieveDataMethod((context) =>
                 {
-                    //var options = context.QueryOptions;
+                    var options = context.QueryOptions;
 
-                    int totalRecords = 100;
-                    //var repo = DependencyResolver.Current.GetService<IPersonRepository>();
+                    int totalRecords;
+                    var repo = DependencyResolver.Current.GetService<IPersonRepository>();
 
-                    //string globalSearch = options.GetAdditionalQueryOptionString("search");
+                    string globalSearch = options.GetAdditionalQueryOptionString("search");
 
-                    //string sortColumn = options.GetSortColumnData<string>();
+                    string sortColumn = options.GetSortColumnData<string>();
 
-                    //var items = repo.GetData(out totalRecords, globalSearch, options.GetLimitOffset(), options.GetLimitRowcount(),
-                    //    sortColumn, options.SortDirection == SortDirection.Dsc);
-
-                    var items = new List<Person>() { new Person() { FirstName = "Okan" } };
+                    var items = repo.GetData(out totalRecords, globalSearch, options.GetLimitOffset(), options.GetLimitRowcount(),
+                        sortColumn, options.SortDirection == SortDirection.Dsc);
 
                     return new QueryResult<Person>()
                     {

--- a/MVCGridExample/Content/MVCGridConfig.txt
+++ b/MVCGridExample/Content/MVCGridConfig.txt
@@ -28,6 +28,7 @@ namespace MVCGridExample
                 .AddColumns(cols =>
                 {
                     cols.Add("Id").WithValueExpression((p, c) => c.UrlHelper.Action("detail", "demo", new { id = p.Id }))
+                        .WithHeaderTextExpression(() => new Random().Next().ToString())
                         .WithValueTemplate("<a href='{Value}'>{Model.Id}</a>", false)
                         .WithPlainTextValueExpression(p => p.Id.ToString());
                     cols.Add("FirstName").WithHeaderText("First Name")
@@ -60,17 +61,19 @@ namespace MVCGridExample
                 //.WithAdditionalSetting(MVCGrid.Rendering.BootstrapRenderingEngine.SettingNameTableClass, "notreal") // Example of changing table css class
                 .WithRetrieveDataMethod((context) =>
                 {
-                    var options = context.QueryOptions;
+                    //var options = context.QueryOptions;
 
-                    int totalRecords;
-                    var repo = DependencyResolver.Current.GetService<IPersonRepository>();
+                    int totalRecords = 100;
+                    //var repo = DependencyResolver.Current.GetService<IPersonRepository>();
 
-                    string globalSearch = options.GetAdditionalQueryOptionString("search");
+                    //string globalSearch = options.GetAdditionalQueryOptionString("search");
 
-                    string sortColumn = options.GetSortColumnData<string>();
+                    //string sortColumn = options.GetSortColumnData<string>();
 
-                    var items = repo.GetData(out totalRecords, globalSearch, options.GetLimitOffset(), options.GetLimitRowcount(),
-                        sortColumn, options.SortDirection == SortDirection.Dsc);
+                    //var items = repo.GetData(out totalRecords, globalSearch, options.GetLimitOffset(), options.GetLimitRowcount(),
+                    //    sortColumn, options.SortDirection == SortDirection.Dsc);
+
+                    var items = new List<Person>() { new Person() { FirstName = "Okan" } };
 
                     return new QueryResult<Person>()
                     {

--- a/MVCGridExample/Controllers/TestController.cs
+++ b/MVCGridExample/Controllers/TestController.cs
@@ -45,6 +45,7 @@ namespace MVCGrid.Web.Controllers
                 .WithAllowChangingPageSize(false)
                 .WithFiltering(true)
                 .WithNoResultsMessage("Please enter a year to search for. No results found.")
+                .WithNoResultsMessageExpression(() => "beişey")
                 .AddColumns(cols =>
                 {
                     cols.Add("Year").WithHeaderText("Year")


### PR DESCRIPTION
this fix #97,

When we set the QueryStringPrefix as mentioned [here](http://mvcgrid.net/demo/multiple), export not working anymore because export engine doesn't handle export action, querystring for engine is unmatching with engine type.