### PR TITLE
Bugfix: Bound filters - support multi-select list

### DIFF
--- a/MVCGrid/Scripts/MVCGrid.js
+++ b/MVCGrid/Scripts/MVCGrid.js
@@ -55,6 +55,9 @@ var MVCGrid = new function () {
             var option = $(this).attr('data-mvcgrid-option');
 
             var val = MVCGrid.getFilters(gridName)[option];
+            if ($(this).prop("multiple") === true) {
+                val = val.split(',');
+            }
             $(this).val(val);
         });
     };


### PR DESCRIPTION
Problem: Single value select lists work correctly, but multiple select lists don't load values on bound filter load.
Cause: Multiple values need to be split(',') into an array in order to set the select value.
Solution: Add check for multiple prop on select element and handle values accordingly.